### PR TITLE
Add support to auto discovery services

### DIFF
--- a/slo_example.yml
+++ b/slo_example.yml
@@ -14,6 +14,10 @@ slos:
       link: https://grafana.myservice.com/URL
       slack_channel: '_team_a'
 
+    trafficRateRecord:
+      expr: |
+        sum (rate(http_requests_total{job="service-a"}[$window]))
+
     errorRateRecord:
       alertMethod: multi-window
       expr: |


### PR DESCRIPTION
Sometimes the developer does not want to create each individual service declaration, all services metrics already in Prometheus, we could create one rule that can extract SLIs from existing services.

@pedrokiefer 