### PR TITLE
Add simple algorithm draft

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/prometheus/common v0.6.0
 	github.com/prometheus/prometheus v0.0.0-20190525122359-d20e84d0fb64
 	github.com/prometheus/tsdb v0.10.0 // indirect
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/Azure/go-autorest v11.2.8+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OneOfOne/xxhash v1.2.5 h1:zl/OfRA6nftbBK9qTohYBJ5xvw6C/oNKizR7cZGl3cI=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -196,8 +197,6 @@ github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNG
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/prometheus v0.0.0-20190525122359-d20e84d0fb64 h1:3DyLm+sTAJkfLyR/1pJ3L+fU2lFufWbpcgMFlGtqeyA=
 github.com/prometheus/prometheus v0.0.0-20190525122359-d20e84d0fb64/go.mod h1:oYrT4Vs22/NcnoVYXt5m4cIHP+znvgyusahVpyETKTw=
-github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
-github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
 github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
@@ -227,6 +226,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/methods/method.go
+++ b/methods/method.go
@@ -2,9 +2,27 @@ package methods
 
 import "github.com/prometheus/prometheus/pkg/rulefmt"
 
+type AlertErrorOptions struct {
+	ServiceName        string
+	AvailabilityTarget float64
+
+	// important for simple algorithm
+	AlertWindow string
+	AlertWait   string
+}
+
+type AlertLatencyOptions struct {
+	ServiceName string
+	Targets     []LatencyTarget
+
+	// important for simple algorithm
+	AlertWindow string
+	AlertWait   string
+}
+
 type AlertMethod interface {
-	AlertForError(serviceName string, availabilityTarget float64) []rulefmt.Rule
-	AlertForLatency(serviceName string, targets []LatencyTarget) []rulefmt.Rule
+	AlertForError(*AlertErrorOptions) ([]rulefmt.Rule, error)
+	AlertForLatency(*AlertLatencyOptions) ([]rulefmt.Rule, error)
 }
 
 var methods = map[string]AlertMethod{}

--- a/methods/multi-window.go
+++ b/methods/multi-window.go
@@ -10,14 +10,14 @@ import (
 
 type MultiWindowAlgorithm struct{}
 
-func (*MultiWindowAlgorithm) AlertForError(serviceName string, availabilityTarget float64) []rulefmt.Rule {
+func (*MultiWindowAlgorithm) AlertForError(opts *AlertErrorOptions) ([]rulefmt.Rule, error) {
 	rules := []rulefmt.Rule{
 		{
-			Alert: "slo:" + serviceName + ".errors.page",
+			Alert: "slo:" + opts.ServiceName + ".errors.page",
 			Expr: multiBurnRate(MultiRateErrorOpts{
 				Metric: "slo:service_errors_total",
-				Labels: labels.New(labels.Label{"service", serviceName}),
-				Value:  (1 - availabilityTarget/100),
+				Labels: labels.New(labels.Label{"service", opts.ServiceName}),
+				Value:  (1 - opts.AvailabilityTarget/100),
 				Kind:   "page",
 			}),
 			Annotations: map[string]string{},
@@ -26,11 +26,11 @@ func (*MultiWindowAlgorithm) AlertForError(serviceName string, availabilityTarge
 			},
 		},
 		{
-			Alert: "slo:" + serviceName + ".errors.ticket",
+			Alert: "slo:" + opts.ServiceName + ".errors.ticket",
 			Expr: multiBurnRate(MultiRateErrorOpts{
 				Metric: "slo:service_errors_total",
-				Labels: labels.New(labels.Label{"service", serviceName}),
-				Value:  (1 - availabilityTarget/100),
+				Labels: labels.New(labels.Label{"service", opts.ServiceName}),
+				Value:  (1 - opts.AvailabilityTarget/100),
 				Kind:   "ticket",
 			}),
 			Annotations: map[string]string{},
@@ -40,17 +40,17 @@ func (*MultiWindowAlgorithm) AlertForError(serviceName string, availabilityTarge
 		},
 	}
 
-	return rules
+	return rules, nil
 }
 
-func (*MultiWindowAlgorithm) AlertForLatency(serviceName string, targets []LatencyTarget) []rulefmt.Rule {
+func (*MultiWindowAlgorithm) AlertForLatency(opts *AlertLatencyOptions) ([]rulefmt.Rule, error) {
 	rules := []rulefmt.Rule{
 		{
-			Alert: "slo:" + serviceName + ".latency.page",
+			Alert: "slo:" + opts.ServiceName + ".latency.page",
 			Expr: multiBurnRateLatency(MultiRateLatencyOpts{
 				Metric:  "slo:service_latency",
-				Label:   labels.Label{"service", serviceName},
-				Buckets: targets,
+				Label:   labels.Label{"service", opts.ServiceName},
+				Buckets: opts.Targets,
 				Kind:    "page",
 			}),
 			Annotations: map[string]string{},
@@ -59,11 +59,11 @@ func (*MultiWindowAlgorithm) AlertForLatency(serviceName string, targets []Laten
 			},
 		},
 		{
-			Alert: "slo:" + serviceName + ".latency.ticket",
+			Alert: "slo:" + opts.ServiceName + ".latency.ticket",
 			Expr: multiBurnRateLatency(MultiRateLatencyOpts{
 				Metric:  "slo:service_latency",
-				Label:   labels.Label{"service", serviceName},
-				Buckets: targets,
+				Label:   labels.Label{"service", opts.ServiceName},
+				Buckets: opts.Targets,
 				Kind:    "ticket",
 			}),
 			Annotations: map[string]string{},
@@ -73,7 +73,7 @@ func (*MultiWindowAlgorithm) AlertForLatency(serviceName string, targets []Laten
 		},
 	}
 
-	return rules
+	return rules, nil
 }
 
 type MultiRateErrorOpts struct {

--- a/methods/simple.go
+++ b/methods/simple.go
@@ -1,0 +1,90 @@
+package methods
+
+import (
+	"fmt"
+	"strings"
+
+	samples "github.com/globocom/slo-generator/samples"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+)
+
+type SimpleAlgorithm struct{}
+
+func (*SimpleAlgorithm) AlertForError(opts *AlertErrorOptions) ([]rulefmt.Rule, error) {
+	var waitFor model.Duration
+
+	if err := samples.ValidateSample(opts.AlertWindow); err != nil {
+		return nil, err
+	}
+	if opts.AlertWait != "" {
+		var err error
+		waitFor, err = model.ParseDuration(opts.AlertWait)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ruleLabels := labels.New(labels.Label{"service", opts.ServiceName})
+	errorLimit := (1 - opts.AvailabilityTarget/100)
+	rules := []rulefmt.Rule{
+		{
+			Alert:       "slo:" + opts.ServiceName + ".errors.page",
+			Expr:        fmt.Sprintf("slo:service_errors_total:ratio_rate_%s%s > %.3g", opts.AlertWindow, ruleLabels.String(), errorLimit),
+			For:         waitFor,
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"severity": "page",
+			},
+		},
+	}
+
+	return rules, nil
+}
+
+func (*SimpleAlgorithm) AlertForLatency(opts *AlertLatencyOptions) ([]rulefmt.Rule, error) {
+	var waitFor model.Duration
+
+	if err := samples.ValidateSample(opts.AlertWindow); err != nil {
+		return nil, err
+	}
+	if opts.AlertWait != "" {
+		var err error
+		waitFor, err = model.ParseDuration(opts.AlertWait)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rules := []rulefmt.Rule{
+		{
+			Alert:       "slo:" + opts.ServiceName + ".latency.page",
+			Expr:        simpleLatency(opts),
+			For:         waitFor,
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"severity": "page",
+			},
+		},
+	}
+
+	return rules, nil
+}
+
+func simpleLatency(opts *AlertLatencyOptions) string {
+	conditions := []string{}
+
+	for _, target := range opts.Targets {
+		value := (1 - ((100 - target.Target) * 0.01))
+
+		lbs := labels.New(labels.Label{"service", opts.ServiceName}, labels.Label{"le", target.LE})
+		condition := fmt.Sprintf(`slo:service_latency:ratio_rate_%s%s < %.3g`, opts.AlertWindow, lbs.String(), value)
+
+		conditions = append(conditions, condition)
+	}
+
+	return strings.Join(conditions, " or ")
+}
+
+var _ = register(&SimpleAlgorithm{}, "simple")

--- a/samples/samples.go
+++ b/samples/samples.go
@@ -1,4 +1,9 @@
-package slo
+package samples
+
+import (
+	"fmt"
+	"strings"
+)
 
 type sample struct {
 	Name     string
@@ -6,7 +11,7 @@ type sample struct {
 	Buckets  []string
 }
 
-var defaultSamples = []sample{
+var DefaultSamples = []sample{
 	{
 		Name:     "short",
 		Interval: "30s",
@@ -26,7 +31,7 @@ var defaultSamples = []sample{
 
 var disabletBucketsForTickets = []string{"3d", "1d", "2h"}
 
-func isTicketSample(sample string) bool {
+func IsTicketSample(sample string) bool {
 	for _, bucketSample := range disabletBucketsForTickets {
 		if bucketSample == sample {
 			return true
@@ -34,4 +39,18 @@ func isTicketSample(sample string) bool {
 	}
 
 	return false
+}
+
+func ValidateSample(sample string) error {
+	validSamples := []string{}
+	for _, defaultSample := range DefaultSamples {
+		for _, bucket := range defaultSample.Buckets {
+			if bucket == sample {
+				return nil
+			}
+
+			validSamples = append(validSamples, bucket)
+		}
+	}
+	return fmt.Errorf("Sample %s is not a valid sample, valid samples: %s", sample, strings.Join(validSamples, ","))
 }

--- a/slo/simple_slo_test.go
+++ b/slo/simple_slo_test.go
@@ -1,0 +1,118 @@
+package slo
+
+import (
+	"testing"
+	"time"
+
+	methods "github.com/globocom/slo-generator/methods"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleSLOGenerateAlertRules(t *testing.T) {
+	slo := &SLO{
+		Name: "my-team.my-service.payment",
+		Objectives: Objectives{
+			Availability: 99.9,
+			Latency: []methods.LatencyTarget{
+				{
+					LE:     "0.1",
+					Target: 95,
+				},
+				{
+					LE:     "0.5",
+					Target: 99,
+				},
+			},
+		},
+		ErrorRateRecord: ExprBlock{
+			AlertMethod: "simple",
+			AlertWindow: "1h",
+			AlertWait:   "5m",
+			Expr:        "kk",
+		},
+		LatencyRecord: ExprBlock{
+			AlertMethod: "simple",
+			AlertWindow: "30m",
+			AlertWait:   "2m",
+			Expr:        "kk",
+		},
+		Labels: map[string]string{
+			"channel": "my-channel",
+		},
+		Annotations: map[string]string{
+			"message":   "Service A has lower SLI",
+			"link":      "http://wiki.ops/1234",
+			"dashboard": "http://grafana.globo.com",
+		},
+	}
+
+	alertRules := slo.GenerateAlertRules(nil, false)
+	assert.Len(t, alertRules, 2)
+
+	assert.Equal(t, alertRules[0], rulefmt.Rule{
+		Alert: "slo:my-team.my-service.payment.errors.page",
+		Expr:  "slo:service_errors_total:ratio_rate_1h{service=\"my-team.my-service.payment\"} > 0.001",
+		Labels: map[string]string{
+			"channel":  "my-channel",
+			"severity": "page",
+		},
+		For:         model.Duration(time.Second * 5 * 60),
+		Annotations: slo.Annotations,
+	})
+
+	assert.Equal(t, alertRules[1], rulefmt.Rule{
+		Alert: "slo:my-team.my-service.payment.latency.page",
+		Expr:  ("slo:service_latency:ratio_rate_30m{le=\"0.1\", service=\"my-team.my-service.payment\"} < 0.95 or slo:service_latency:ratio_rate_30m{le=\"0.5\", service=\"my-team.my-service.payment\"} < 0.99"),
+		Labels: map[string]string{
+			"channel":  "my-channel",
+			"severity": "page",
+		},
+		For:         model.Duration(time.Second * 2 * 60),
+		Annotations: slo.Annotations,
+	})
+}
+
+func TestSimpleSLOInvalid(t *testing.T) {
+	slo := &SLO{
+		Name: "my-team.my-service.payment",
+		Objectives: Objectives{
+			Availability: 99.9,
+			Latency: []methods.LatencyTarget{
+				{
+					LE:     "0.1",
+					Target: 95,
+				},
+				{
+					LE:     "0.5",
+					Target: 99,
+				},
+			},
+		},
+		ErrorRateRecord: ExprBlock{
+			AlertMethod: "simple",
+			AlertWindow: "22m",
+			AlertWait:   "5m",
+			Expr:        "kk",
+		},
+		LatencyRecord: ExprBlock{
+			AlertMethod: "simple",
+			AlertWindow: "33m",
+			AlertWait:   "2m",
+			Expr:        "kk",
+		},
+		Labels: map[string]string{
+			"channel": "my-channel",
+		},
+		Annotations: map[string]string{
+			"message":   "Service A has lower SLI",
+			"link":      "http://wiki.ops/1234",
+			"dashboard": "http://grafana.globo.com",
+		},
+	}
+
+	assert.PanicsWithValue(t, "Could not generate alert, err: Sample 22m is not a valid sample, valid samples: 5m,30m,1h,2h,6h,1d,3d", func() {
+		slo.GenerateAlertRules(nil, false)
+	})
+}


### PR DESCRIPTION
This simple algorithm will cover four first alert methods.

example:

```
slos:
  - name: myteam-a.service-a
    objectives:
      availability: 99
      latency:
      - le: 5.0 # 95% < 5s
        target: 95

      - le: 10.0 # 97% < 10s
        target: 97
    labels:
      slack_channel: '_team_a'
      platform: myplatform
    annotations:
      message: Service A Error Budget consumption
      link: https://grafana.myservice.com/URL

    trafficRateRecord:
      expr: |
        sum (rate(http_requests_total{job="service-a"}[$window]))
    errorRateRecord:
      alertMethod: simple
      alertWindow: 30m
      alertWait: 10m
      expr: |
        sum (rate(http_requests_total{job="service-a", status="5xx"}[$window])) /
        sum (rate(http_requests_total{job="service-a"}[$window]))
    latencyRecord:
      alertMethod: simple
      alertWindow: 30m
      alertWait: 10m
      expr: |
        sum (rate(http_request_duration_seconds_bucket{job="service-a", le="$le"}[$window])) /
        sum (rate(http_requests_total{job="service-a"}[$window]))
```

@pedrokiefer and @vierno could you review my merge request ?