### PR TITLE
Include Burn Rate Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Look the file [slo_example.yml](./examples/slo_example.yml) to see how to parame
 - [x] 1. Target Error Rate ≥ SLO Threshold, using `alertMethod: simple`
 - [x] 2. Increased Alert Window, using `alertMethod: simple`
 - [x] 3. Incrementing Alert Duration, using `alertMethod: simple`
-- [ ] 4. Alert on Burn Rate
+- [x] 4. Alert on Burn Rate `alertMethod: simple and burnRate: <rate>`
 - [x] 5. Multiple Burn Rate Alerts, using `alertMethod: multi-window and shortWindow: false`
 - [x] 6. Multiwindow, Multi-Burn-Rate Alerts, using `alertMethod: multi-window`
 

--- a/methods/method.go
+++ b/methods/method.go
@@ -33,6 +33,7 @@ type AlertErrorOptions struct {
 
 	Windows     []Window
 	ShortWindow bool
+	BurnRate    float64
 
 	// important for simple algorithm
 	AlertWindow string
@@ -46,6 +47,7 @@ type AlertLatencyOptions struct {
 
 	Windows     []Window
 	ShortWindow bool
+	BurnRate    float64
 
 	// important for simple algorithm
 	AlertWindow string

--- a/methods/multi-window.go
+++ b/methods/multi-window.go
@@ -26,7 +26,7 @@ func (*MultiWindowAlgorithm) AlertForError(opts *AlertErrorOptions) ([]rulefmt.R
 				Rates:  ratesMap[severity],
 				Metric: "slo:service_errors_total",
 				Labels: labels.New(labels.Label{"service", opts.ServiceName}),
-				Value:  (1 - opts.AvailabilityTarget/100),
+				Value:  1 - opts.AvailabilityTarget/100,
 			}),
 			Annotations: map[string]string{},
 			Labels: map[string]string{

--- a/slo/simple_slo_test.go
+++ b/slo/simple_slo_test.go
@@ -28,6 +28,7 @@ func TestSimpleSLOGenerateAlertRules(t *testing.T) {
 			},
 		},
 		ErrorRateRecord: ExprBlock{
+			BurnRate:    2,
 			AlertMethod: "simple",
 			AlertWindow: "1h",
 			AlertWait:   "5m",
@@ -54,7 +55,7 @@ func TestSimpleSLOGenerateAlertRules(t *testing.T) {
 
 	assert.Equal(t, alertRules[0], rulefmt.Rule{
 		Alert: "slo:my-team.my-service.payment.errors.page",
-		Expr:  "slo:service_errors_total:ratio_rate_1h{service=\"my-team.my-service.payment\"} > 0.001",
+		Expr:  "slo:service_errors_total:ratio_rate_1h{service=\"my-team.my-service.payment\"} > 2 * 0.001",
 		Labels: map[string]string{
 			"channel":  "my-channel",
 			"severity": "page",
@@ -65,7 +66,7 @@ func TestSimpleSLOGenerateAlertRules(t *testing.T) {
 
 	assert.Equal(t, alertRules[1], rulefmt.Rule{
 		Alert: "slo:my-team.my-service.payment.latency.page",
-		Expr:  "slo:service_latency:ratio_rate_30m{le=\"0.1\", service=\"my-team.my-service.payment\"} < 0.95 or slo:service_latency:ratio_rate_30m{le=\"0.5\", service=\"my-team.my-service.payment\"} < 0.99",
+		Expr:  "slo:service_latency:ratio_rate_30m{le=\"0.1\", service=\"my-team.my-service.payment\"} < 2 * 0.95 or slo:service_latency:ratio_rate_30m{le=\"0.5\", service=\"my-team.my-service.payment\"} < 2 * 0.99",
 		Labels: map[string]string{
 			"channel":  "my-channel",
 			"severity": "page",

--- a/slo/slo.go
+++ b/slo/slo.go
@@ -38,6 +38,7 @@ type SLOSpec struct {
 type ExprBlock struct {
 	AlertMethod string           `yaml:"alertMethod"`
 	AlertWindow string           `yaml:"alertWindow"`
+	BurnRate    float64          `yaml:"burnRate"`
 	AlertWait   string           `yaml:"alertWait"`
 	Windows     []methods.Window `yaml:"windows"`
 	ShortWindow *bool            `yaml:"shortWindow"`
@@ -120,6 +121,7 @@ func (slo *SLO) GenerateAlertRules(sloClass *Class, disableTicket bool) []rulefm
 			Windows:            slo.ErrorRateRecord.Windows,
 			AlertWindow:        slo.ErrorRateRecord.AlertWindow,
 			AlertWait:          slo.ErrorRateRecord.AlertWait,
+			BurnRate:           slo.ErrorRateRecord.BurnRate,
 		})
 		if err != nil {
 			log.Panicf("Could not generate alert, err: %s", err.Error())
@@ -142,6 +144,7 @@ func (slo *SLO) GenerateAlertRules(sloClass *Class, disableTicket bool) []rulefm
 				Windows:     slo.LatencyRecord.Windows,
 				AlertWindow: slo.LatencyRecord.AlertWindow,
 				AlertWait:   slo.LatencyRecord.AlertWait,
+				BurnRate:    slo.ErrorRateRecord.BurnRate,
 			})
 			if err != nil {
 				log.Panicf("Could not generate alert, err: %s", err.Error())


### PR DESCRIPTION
I notice that Burn Rate Alert has the same structure of Simple Alert but with a custom multiplier. Therefore, I only included a multiplier factor in AlertOptions. If the multiplier is not given, a default multiplier equals to one is used in place.

![image](https://user-images.githubusercontent.com/7620947/95142047-27ff9380-0749-11eb-87ef-d5f3e9d75ce1.png)

What do you think about it? A separated alert is better or this is a good option? I tried to avoid code duplication.

Ref https://github.com/globocom/slo-generator/issues/3